### PR TITLE
Implement CAT-US3 (product deletion) and CAT-US4 (product update).

### DIFF
--- a/CATprogress.txt
+++ b/CATprogress.txt
@@ -92,8 +92,8 @@ Frontend
 
   US1  Catalogue Initialization          PARTIAL (implicit schema only)
   US2  Product Creation                  PARTIAL (API only; weak validation)
-  US3  Product Discontinuation/Removal   NOT STARTED
-  US4  Product Data Maintenance          NOT STARTED
+  US3  Product Discontinuation/Removal   DONE
+  US4  Product Data Maintenance          DONE
   US5  Internal Product Search           NOT STARTED
   US6  Merchant Catalogue Browsing       PARTIAL (read-only OK; stock masking NO)
   US7  Stock Delivery Recording          NOT STARTED
@@ -250,41 +250,28 @@ ACCEPTANCE CRITERION 1:
   "The system must prompt for a confirmation Yes/No before a product is
    deleted."
 
-  STATUS: ❌  NOT STARTED (no delete flow at all)
+  STATUS: ✅  DONE
 
-  TODAY:
-    • ProductController has no @DeleteMapping.
-    • No admin UI for delete.
-
-  WORK TO COMPLETE:
-    • Frontend: delete button opens modal/dialog "Are you sure? Yes / No";
-      only on Yes call DELETE API.
-    • Alternatively document that browser confirm() meets "prompt" for
-      prototype (weaker UX).
+  IMPLEMENTED:
+    • DELETE /api/products/{id} endpoint on ProductController (ADMIN only).
+    • Frontend: Catalogue.jsx shows a modal with "Yes" / "No" buttons
+      before calling DELETE. Only on "Yes" does the API call fire.
 
 
 ACCEPTANCE CRITERION 2:
   "The system must log the deletion activity, including which user performed
    the action."
 
-  STATUS: ❌  NOT STARTED
+  STATUS: ✅  DONE
 
-  TODAY:
-    • No ProductDeletionLog entity or generic audit table for catalogue.
-
-  WORK TO COMPLETE:
-    • New entity (e.g. product_deletion_logs): productId/code snapshot,
-      description snapshot, deletedBy (User FK), deletedAt.
-    • On successful delete, insert log row in same transaction.
-    • Mirror pattern used for ACC StandingChangeLog if desired.
-
-
-DESIGN NOTE (brief alignment):
-  Hard DELETE breaks historical order line references unless orders store
-  product snapshot (you already have unitPriceAtOrder on order items — check
-  if product FK allows null or if soft-delete is better).  Consider:
-    • Soft delete: discontinued flag + hide from merchant catalogue; OR
-    • Hard delete only when no order history (enforce in service).
+  IMPLEMENTED:
+    • New entity ProductDeletionLog (table product_deletion_logs): snapshots
+      productId, productCode, description, deletedBy (User FK), deletedAt.
+    • ProductService.deleteProduct() saves the log and deletes the product
+      in a single @Transactional method.
+    • Hard delete only when no order_items reference the product; otherwise
+      returns 409 CONFLICT (preserves historical order integrity).
+    • Mirrors the StandingChangeLog pattern from ACC-US5.
 
 
 ──────────────────────────────────────────────────────────────────────────────
@@ -298,28 +285,27 @@ Title:
 ACCEPTANCE CRITERION 1:
   "The system must prevent the modification of an existing Product ID."
 
-  STATUS: ❌  NOT STARTED (no update endpoint)
+  STATUS: ✅  DONE
 
-  TODAY:
-    • No PUT /api/products/{id}.
-
-  WORK TO COMPLETE:
-    • PUT endpoint with UpdateProductRequest that omits id OR ignores id in
-      body; only allow changing description, price, availability (and later
-      min threshold).  Path variable id is the sole identifier.
+  IMPLEMENTED:
+    • PUT /api/products/{id} endpoint on ProductController (ADMIN only).
+    • UpdateProductRequest DTO has NO productCode field — the Product ID
+      is immutable. Only description, price, and availabilityCount can be
+      changed. Path variable id (surrogate PK) is the sole identifier.
 
 
 ACCEPTANCE CRITERION 2:
   "The system must validate that any updated price or stock level
    (Availability) remains non-negative."
 
-  STATUS: ❌  NOT STARTED
+  STATUS: ✅  DONE
 
-  WORK TO COMPLETE:
-    • @DecimalMin on price (> 0 if business rule matches US2).
-    • @Min(0) on availability updates.
-    • api.js: add updateProduct(id, payload).
-    • Admin UI: edit row or edit form on catalogue management page.
+  IMPLEMENTED:
+    • UpdateProductRequest DTO: @NotNull @DecimalMin("0.01") on price
+      (greater than zero, matching US2); @NotNull @Min(0) on availabilityCount.
+    • api.js: updateProduct(id, payload) → PUT /api/products/{id}.
+    • Admin UI: Catalogue.jsx edit modal prefilled from row; submit calls
+      updateProduct; validation errors surfaced to user.
 
 
 ──────────────────────────────────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **IPOS-SA** — a pharmaceutical stock and order management prototype for InfoPharma Ltd.
 
-- **Frontend**: React + Vite (JS), runs on `http://localhost:5173`
+- **Frontend**: React 19 + Vite 6 (JS, no TypeScript), runs on `http://localhost:5173`
 - **Backend**: Spring Boot 3.4.x, Java 17, runs on `http://localhost:8080`
 - **Database**: MySQL 8+ (`ipos_sa` schema); Hibernate `ddl-auto=update` auto-manages schema
 
@@ -24,6 +24,7 @@ cd backend
 mvn spring-boot:run                                    # start dev server
 mvn test "-Dspring.profiles.active=test"               # run all tests (H2 in-memory)
 mvn test "-Dspring.profiles.active=test" -Dtest=MerchantAccountServiceTest  # single test class
+mvn test "-Dspring.profiles.active=test" "-Dtest=MerchantAccountServiceTest#testMethodName"  # single test method
 ```
 
 ### Frontend
@@ -55,22 +56,70 @@ Configure `backend/src/main/resources/application.properties` with your MySQL cr
 | Merchant Profiles | IPOS-SA-MER | ✅ Complete |
 | Reporting | IPOS-SA-RPRT | ❌ Stub only |
 
-### Backend Structure (`backend/src/main/java/com/ipos/`)
+### Backend Layers (`backend/src/main/java/com/ipos/`)
 
+Standard Spring Boot layered architecture: **Controller → Service → Repository → Entity**. All business logic lives in services; controllers only parse HTTP and delegate.
+
+**Key Services:**
+- **`service/OrderService.java`** — Most complex service. Handles the entire order pipeline atomically: standing check → stock validation + decrement → price snapshot → discount calc (FIXED or FLEXIBLE credit) → credit limit enforcement → save.
+- **`service/MerchantAccountService.java`** — Merchant creation (atomic User + MerchantProfile), flexible tier validation, month-close settlement with rebate calculation.
+- **`service/UserService.java`** — Staff user CRUD. Explicitly rejects `role=MERCHANT` (must use MerchantAccountService).
+
+**Key Security:**
 - **`security/SecurityConfig.java`** — CSRF (`CookieCsrfTokenRepository`), CORS, session config, and all URL-level RBAC rules. **Primary source of truth for API authorization.**
-- **`service/OrderService.java`** — The most complex service. Handles the entire order pipeline atomically: standing check → stock validation + decrement → price snapshot → discount calc (FIXED or FLEXIBLE credit) → credit limit enforcement → save.
-- **`service/MerchantAccountService.java`** — Merchant creation (atomic User + MerchantProfile), flexible month-close settlement, standing transitions.
+- **`security/IposUserDetailsService.java`** — Loads users for Spring Security; maps role to `ROLE_` authority prefix.
+
+**Key Config:**
 - **`config/DataBootstrap.java`** — Seeds default users on startup when `ipos.bootstrap.enabled=true`.
-- **`entity/MerchantProfile.java`** — Core merchant state: `accountStatus` (INACTIVE/ACTIVE), `standing` (NORMAL/IN_DEFAULT/SUSPENDED), `inDefaultSince`, `flexibleTiersJson` (JSON), `flexibleDiscountCredit`, `chequeRebatePending`.
-- **`entity/Order.java`** + **`entity/OrderItem.java`** — Orders snapshot `unitPriceAtOrder` at placement time. `totalDue` reflects applied discounts.
-- **`entity/StandingChangeLog.java`** — Audit log for every standing transition (ACC-US5).
+
+**Entities & Relationships:**
+- `User` — id, name, username, passwordHash, role (ADMIN/MANAGER/MERCHANT). Optional 1:1 with MerchantProfile.
+- `MerchantProfile` — 1:1 with User. Holds contactEmail, contactPhone, addressLine, creditLimit, accountStatus (ACTIVE/INACTIVE), standing (NORMAL/IN_DEFAULT/SUSPENDED), discount plan (FIXED or FLEXIBLE), inDefaultSince, flexibleDiscountCredit, chequeRebatePending.
+- `Product` — id, description, price, availabilityCount. No SKU/business ID yet.
+- `Order` → M:1 User (merchant), 1:M OrderItem. Snapshots grossTotal, fixedDiscountAmount, flexibleCreditApplied, totalDue at placement.
+- `OrderItem` → M:1 Order, M:1 Product. Snapshots unitPriceAtOrder.
+- `MonthlyRebateSettlement` — M:1 User. Records month-close rebate calculations. Unique constraint on (merchant_id, settlement_year_month).
+- `StandingChangeLog` — Audit log for every standing transition (who, when, from, to).
+
+### API Endpoints
+
+| Endpoint | Methods | Access |
+|----------|---------|--------|
+| `/api/auth/login` | POST | Public |
+| `/api/auth/logout`, `/api/auth/me` | POST, GET | Authenticated |
+| `/api/users` | GET, POST | ADMIN |
+| `/api/merchant-accounts` | POST | ADMIN |
+| `/api/merchant-profiles` | GET, GET/{userId}, PUT/{userId} | MANAGER, ADMIN |
+| `/api/merchant-profiles/close-month` | POST | MANAGER, ADMIN |
+| `/api/products` | GET | Authenticated |
+| `/api/products` | POST | ADMIN |
+| `/api/products` | PUT, DELETE | ADMIN (security rules exist, **controller methods not yet implemented**) |
+| `/api/orders` | GET, POST | Authenticated |
+| `/api/reports` | * | MANAGER, ADMIN (security rules exist, **no controller yet**) |
 
 ### Frontend Structure (`frontend/src/`)
 
+No router library — uses simple `currentPage` state in App.jsx.
+
 - **`auth/rbac.js`** — **Single source of truth for frontend RBAC.** Defines `ACCESS_MATRIX`, `ROUTE_PACKAGES`, and exported helper functions. All role checks must use this module.
-- **`auth/AuthContext.jsx`** — Auth state, login/logout, session restoration (`GET /api/auth/me` on load), and `fetchWithAuth()` which automatically attaches the `X-XSRF-TOKEN` header.
+- **`auth/AuthContext.jsx`** — Auth state, login/logout, session restoration (`GET /api/auth/me` on load), and `fetchWithAuth()` which automatically attaches the `X-XSRF-TOKEN` header and `credentials: "include"`.
 - **`App.jsx`** — Builds navigation and renders pages dynamically based on `getAccessibleRoutes(role)` from `rbac.js`.
 - **`api.js`** — All API calls in one place. Uses `fetchWithAuth` from `AuthContext`.
+
+**Frontend RBAC Matrix:**
+
+| Role | ACC | CAT | ORD | RPRT | MER |
+|------|-----|-----|-----|------|-----|
+| MERCHANT | ✗ | ✓ | ✓ | ✗ | ✗ |
+| MANAGER | ✗ | ✓ | ✓ | ✓ | ✓ |
+| ADMIN | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+**Route → Component mapping** (in `App.jsx`):
+- `catalogue` → `Catalogue.jsx` (product listing table)
+- `order` → `OrderForm.jsx` (place orders with discount breakdown display)
+- `reporting` → `ReportingPlaceholder.jsx` (stub)
+- `accounts` → `MerchantCreate.jsx` (admin form for atomic merchant+profile creation)
+- `merchants` → `MerchantManagement.jsx` (edit profiles, standing, month-close settlement)
 
 ---
 
@@ -81,13 +130,25 @@ Session-based (not JWT). JSESSIONID cookie + CSRF protection via `XSRF-TOKEN` co
 
 ### Discount Logic
 - **FIXED**: Discount applied at order placement time — `totalDue = grossTotal − (grossTotal × percent/100)`.
-- **FLEXIBLE**: No per-order discount. Month-close settlement computes the rebate from monthly spend; stored as `flexibleDiscountCredit` on the profile, consumed on subsequent orders.
+- **FLEXIBLE**: No per-order discount. Month-close settlement computes the rebate from monthly spend tiers; stored as `flexibleDiscountCredit` on the profile, consumed on subsequent orders via `min(availableCredit, grossTotal)`.
+
+### Flexible Tiers JSON Format
+```json
+[{"maxExclusive":1000,"percent":1}, {"maxExclusive":2000,"percent":2}, {"percent":3}]
+```
+Last tier omits `maxExclusive` (catch-all). Validated at account creation and profile update.
 
 ### Standing Rules
 Merchants must be in `NORMAL` standing to place orders. Managers (and Admins) can transition `IN_DEFAULT → NORMAL` or `IN_DEFAULT → SUSPENDED` only — and only after 30 days (`inDefaultSince`). All transitions are audited in `standing_change_logs`.
 
 ### Merchant Account Creation
 `POST /api/merchant-accounts` (ADMIN only) is the only valid way to create a MERCHANT user. `POST /api/users` explicitly rejects `role=MERCHANT`. The creation is fully atomic: no `User` row exists without an accompanying `MerchantProfile`.
+
+### Credit Limit Enforcement
+Outstanding exposure = sum of `totalDue` across all non-CANCELLED orders for a merchant. New orders are rejected if `existingExposure + newOrder.totalDue > creditLimit`.
+
+### Merchant Isolation (ORD-US1)
+If the caller is a MERCHANT, `OrderService.placeOrder()` forces `merchantId` to the caller's own user ID at the service layer — merchants cannot place orders for others.
 
 ### Adding a New Screen
 1. Create `NewFeature.jsx` in `frontend/src/`.
@@ -104,21 +165,26 @@ Merchants must be in `NORMAL` standing to place orders. Managers (and Admins) ca
 
 ## Tests
 
-Unit tests live at `backend/src/test/java/com/ipos/service/MerchantAccountServiceTest.java` (20 tests, JUnit 5 + Mockito). Test profile uses H2 in-memory DB with bootstrap disabled (`application-test.properties`). There are no `ProductController` or `WebMvc` integration tests yet.
+Unit tests live at `backend/src/test/java/com/ipos/service/MerchantAccountServiceTest.java` (20 tests, JUnit 5 + Mockito). Test profile uses H2 in-memory DB with bootstrap disabled (`application-test.properties`). Tests cover: merchant account creation, tier validation, discount calculations, standing guards, credit limits, and merchant isolation.
+
+There are no frontend tests, no `ProductController` tests, and no `WebMvc` integration tests yet.
 
 ---
 
 ## User Story Backlog (What's Left)
 
-Detailed status in `ACCprogress.txt` (ACC — complete) and `CATprogress.txt` (CAT — largely incomplete). Key remaining CAT gaps:
+Detailed status in `ACCprogress.txt` (ACC — complete) and `CATprogress.txt` (CAT — largely incomplete). Key remaining gaps:
 
+**CAT (Catalogue & Inventory):**
+- **CAT-US2**: `POST /api/products` exists but has weak validation (no DTO, no unique SKU field).
 - **CAT-US3/US4**: No `PUT`/`DELETE` on `ProductController` (security rules exist, controller methods don't).
 - **CAT-US5/US6**: No product search endpoint; merchants see raw stock counts (should show Available/Out of Stock only).
 - **CAT-US7**: No stock delivery recording (`StockDelivery` entity doesn't exist).
 - **CAT-US8/US9**: No `minStockThreshold` field on `Product`; no low-stock warnings.
 - **CAT-US10**: `ReportingPlaceholder.jsx` is a stub; no report controllers.
 
-ORD gap: `GET /api/orders` returns all orders regardless of role — merchant-scoped listing not implemented.
+**ORD (Orders):**
+- `GET /api/orders` returns all orders regardless of role — merchant-scoped listing not implemented.
 
 ---
 
@@ -131,3 +197,11 @@ ORD gap: `GET /api/orders` returns all orders regardless of role — merchant-sc
 | `merchant` | `merchant123` | MERCHANT |
 
 Set `ipos.bootstrap.enabled=false` once real accounts exist.
+
+---
+
+## Reference Documentation
+
+- `RBAC.md` — Full RBAC architecture and role/permission matrix
+- `ACCprogress.txt` — ACC epic user story status (all 6 complete)
+- `CATprogress.txt` — CAT epic user story status with implementation gaps and suggested order

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Invoke-RestMethod -Uri "http://localhost:8080/api/products" -Method Post -Conten
 |----------------|--------------------|--------|
 | **IPOS-SA-ACC** | Implemented (prototype) | Merchant onboarding (`POST /api/merchant-accounts`, validated DTO), staff users (`/api/users`), RBAC. See **`ACCprogress.txt`**. |
 | **IPOS-SA-MER** | Implemented (prototype) | Merchant **profiles**: `GET`/`PUT /api/merchant-profiles`, flexible **month-close** (`POST .../close-month`), contact edits, standing rules (`IN_DEFAULT` → `NORMAL`/`SUSPENDED` with 30-day rule for managers), **`StandingChangeLog`** audit. Manager + Admin only (not merchants). Documented in **`ACCprogress.txt`** / **`RBAC.md`**. |
-| **IPOS-SA-CAT** | Partial | `Product` entity, `GET`/`POST /api/products` (no `PUT`/`DELETE` on controller yet — security rules exist for when added). Catalogue + order UIs; **no** admin catalogue UI, search, deliveries, min-stock, or merchant stock masking. See **`CATprogress.txt`**. |
+| **IPOS-SA-CAT** | Partial | `Product` entity, `GET`/`POST`/`PUT`/`DELETE /api/products` (ADMIN). Admin catalogue UI with create, edit modal, and delete Yes/No confirmation. `ProductDeletionLog` audit entity. **No** search, deliveries, min-stock, or merchant stock masking yet. See **`CATprogress.txt`**. |
 | **IPOS-SA-ORD** | Partial | `POST /api/orders`: stock decrement, price snapshot, discounts, credit limit, **ORD-US1** (merchants forced to own `merchantId`). `GET /api/orders` returns **all** orders for any authenticated user (merchant-scoped list not implemented). Invoices/payments/status workflow still to do. |
 | **IPOS-SA-RPRT** | Stub | `ReportingPlaceholder.jsx`; `/api/reports/**` secured for manager/admin — **no** report controllers yet. |
 
@@ -275,7 +275,7 @@ Invoke-RestMethod -Uri "http://localhost:8080/api/products" -Method Post -Conten
 | Merchant profiles | `GET`/`PUT /api/merchant-profiles`, `GET /api/merchant-profiles/{userId}`, `POST /api/merchant-profiles/close-month` | MANAGER, ADMIN |
 | Staff users | `/api/users/**` | ADMIN |
 | Products | `GET /api/products` | Authenticated |
-| Products | `POST`/`PUT`/`DELETE /api/products/**` | ADMIN (PUT/DELETE not wired in `ProductController` yet) |
+| Products | `POST`/`PUT`/`DELETE /api/products/**` | ADMIN |
 | Orders | `/api/orders/**` | Authenticated |
 | Reports | `/api/reports/**` | MANAGER, ADMIN (no handlers yet) |
 
@@ -285,7 +285,7 @@ Full detail: **`RBAC.md`** and `backend/.../SecurityConfig.java`.
 
 ## Backend Tests
 
-JUnit 5 **unit** tests live under `backend/src/test/java/` (currently **`com.ipos.service.MerchantAccountServiceTest`** — 20 tests: merchant creation, tier validation, fixed/flexible order math, credit limit, ORD-US1 isolation, `AccountStatus`, `inDefaultSince`, `StandingChangeLog` entity checks, suspended/in-default blocking). **No** `ProductController` / `WebMvc` integration tests yet.
+JUnit 5 **unit** tests live under `backend/src/test/java/` — **`com.ipos.service.MerchantAccountServiceTest`** (20 tests: merchant creation, tier validation, fixed/flexible order math, credit limit, ORD-US1 isolation, `AccountStatus`, `inDefaultSince`, `StandingChangeLog` entity checks, suspended/in-default blocking) and **`com.ipos.cat.CatalogueCatTest`** (15 Mockito unit tests for CAT-US1–US4 + 5 WebMvc integration tests for POST/PUT/DELETE validation and happy paths).
 
 Test profile (H2 in-memory, bootstrap off):
 

--- a/backend/src/main/java/com/ipos/controller/ProductController.java
+++ b/backend/src/main/java/com/ipos/controller/ProductController.java
@@ -22,14 +22,24 @@
 package com.ipos.controller;
 
 import com.ipos.dto.CreateProductRequest;
+import com.ipos.dto.UpdateProductRequest;
 import com.ipos.entity.Product;
+import com.ipos.entity.User;
+import com.ipos.repository.UserRepository;
 import com.ipos.service.ProductService;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -38,9 +48,11 @@ import java.util.List;
 public class ProductController {
 
     private final ProductService productService;
+    private final UserRepository userRepository;
 
-    public ProductController(ProductService productService) {
+    public ProductController(ProductService productService, UserRepository userRepository) {
         this.productService = productService;
+        this.userRepository = userRepository;
     }
 
     /* GET /api/products → Returns every product in the catalogue. */
@@ -53,5 +65,22 @@ public class ProductController {
     @PostMapping
     public Product create(@Valid @RequestBody CreateProductRequest request) {
         return productService.createProduct(request);
+    }
+
+    /* PUT /api/products/{id} → Updates product details (CAT-US4). Product ID is immutable. */
+    @PutMapping("/{id}")
+    public Product update(@PathVariable Long id,
+                          @Valid @RequestBody UpdateProductRequest request) {
+        return productService.updateProduct(id, request);
+    }
+
+    /* DELETE /api/products/{id} → Removes a product with audit log (CAT-US3). */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication authentication) {
+        User deletedBy = userRepository.findByUsername(authentication.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                        "Authenticated user not found in database"));
+        productService.deleteProduct(id, deletedBy);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/ipos/dto/UpdateProductRequest.java
+++ b/backend/src/main/java/com/ipos/dto/UpdateProductRequest.java
@@ -1,0 +1,49 @@
+package com.ipos.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+/**
+ * Request body for updating a catalogue product (CAT-US4).
+ * No productCode field — the Product ID is immutable per acceptance criteria.
+ */
+public class UpdateProductRequest {
+
+    @NotBlank(message = "Description is required")
+    private String description;
+
+    @NotNull(message = "Unit price is required")
+    @DecimalMin(value = "0.01", inclusive = true, message = "Unit price must be greater than zero")
+    private BigDecimal price;
+
+    @NotNull(message = "Availability is required")
+    @Min(value = 0, message = "Availability must not be negative")
+    private Integer availabilityCount;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public void setPrice(BigDecimal price) {
+        this.price = price;
+    }
+
+    public Integer getAvailabilityCount() {
+        return availabilityCount;
+    }
+
+    public void setAvailabilityCount(Integer availabilityCount) {
+        this.availabilityCount = availabilityCount;
+    }
+}

--- a/backend/src/main/java/com/ipos/entity/ProductDeletionLog.java
+++ b/backend/src/main/java/com/ipos/entity/ProductDeletionLog.java
@@ -1,0 +1,65 @@
+/*
+ * JPA Entity for the "product_deletion_logs" table — audit trail for product deletions (CAT-US3).
+ *
+ * Stores a snapshot of the deleted product's data plus who deleted it and when.
+ * Mirrors the pattern used by StandingChangeLog for standing transitions.
+ */
+package com.ipos.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "product_deletion_logs")
+public class ProductDeletionLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "product_id_snapshot", nullable = false)
+    private Long productIdSnapshot;
+
+    @Column(name = "product_code_snapshot", length = 64)
+    private String productCodeSnapshot;
+
+    @Column(name = "description_snapshot")
+    private String descriptionSnapshot;
+
+    @ManyToOne
+    @JoinColumn(name = "deleted_by_user_id", nullable = false)
+    private User deletedBy;
+
+    @Column(name = "deleted_at", nullable = false)
+    private Instant deletedAt;
+
+    public ProductDeletionLog() {
+    }
+
+    // ── Getters & Setters ────────────────────────────────────────────────────
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Long getProductIdSnapshot() { return productIdSnapshot; }
+    public void setProductIdSnapshot(Long productIdSnapshot) { this.productIdSnapshot = productIdSnapshot; }
+
+    public String getProductCodeSnapshot() { return productCodeSnapshot; }
+    public void setProductCodeSnapshot(String productCodeSnapshot) { this.productCodeSnapshot = productCodeSnapshot; }
+
+    public String getDescriptionSnapshot() { return descriptionSnapshot; }
+    public void setDescriptionSnapshot(String descriptionSnapshot) { this.descriptionSnapshot = descriptionSnapshot; }
+
+    public User getDeletedBy() { return deletedBy; }
+    public void setDeletedBy(User deletedBy) { this.deletedBy = deletedBy; }
+
+    public Instant getDeletedAt() { return deletedAt; }
+    public void setDeletedAt(Instant deletedAt) { this.deletedAt = deletedAt; }
+}

--- a/backend/src/main/java/com/ipos/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/ipos/repository/OrderItemRepository.java
@@ -18,5 +18,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
-    // Inherits: save, findById, findAll, deleteById, etc.
+
+    /** True if any order line item references the given product (CAT-US3 delete guard). */
+    boolean existsByProduct_Id(Long productId);
 }

--- a/backend/src/main/java/com/ipos/repository/ProductDeletionLogRepository.java
+++ b/backend/src/main/java/com/ipos/repository/ProductDeletionLogRepository.java
@@ -1,0 +1,9 @@
+package com.ipos.repository;
+
+import com.ipos.entity.ProductDeletionLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductDeletionLogRepository extends JpaRepository<ProductDeletionLog, Long> {
+}

--- a/backend/src/main/java/com/ipos/service/ProductService.java
+++ b/backend/src/main/java/com/ipos/service/ProductService.java
@@ -13,13 +13,19 @@
 package com.ipos.service;
 
 import com.ipos.dto.CreateProductRequest;
+import com.ipos.dto.UpdateProductRequest;
 import com.ipos.entity.Product;
+import com.ipos.entity.ProductDeletionLog;
+import com.ipos.entity.User;
+import com.ipos.repository.OrderItemRepository;
+import com.ipos.repository.ProductDeletionLogRepository;
 import com.ipos.repository.ProductRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 
@@ -28,10 +34,17 @@ public class ProductService {
 
     private final ProductRepository productRepository;
     private final CatalogueService catalogueService;
+    private final OrderItemRepository orderItemRepository;
+    private final ProductDeletionLogRepository productDeletionLogRepository;
 
-    public ProductService(ProductRepository productRepository, CatalogueService catalogueService) {
+    public ProductService(ProductRepository productRepository,
+                          CatalogueService catalogueService,
+                          OrderItemRepository orderItemRepository,
+                          ProductDeletionLogRepository productDeletionLogRepository) {
         this.productRepository = productRepository;
         this.catalogueService = catalogueService;
+        this.orderItemRepository = orderItemRepository;
+        this.productDeletionLogRepository = productDeletionLogRepository;
     }
 
     public List<Product> findAll() {
@@ -40,7 +53,8 @@ public class ProductService {
 
     public Product findById(Long id) {
         return productRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Product not found with id: " + id));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Product not found with id: " + id));
     }
 
     /**
@@ -62,5 +76,48 @@ public class ProductService {
         product.setPrice(request.getPrice());
         product.setAvailabilityCount(request.getAvailabilityCount());
         return productRepository.save(product);
+    }
+
+    /**
+     * Updates description, price, and availabilityCount of an existing product (CAT-US4).
+     * Product code (Product ID) is never changed — immutable per acceptance criteria.
+     */
+    @Transactional
+    public Product updateProduct(Long id, UpdateProductRequest request) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Product not found with id: " + id));
+        product.setDescription(request.getDescription().trim());
+        product.setPrice(request.getPrice());
+        product.setAvailabilityCount(request.getAvailabilityCount());
+        return productRepository.save(product);
+    }
+
+    /**
+     * Hard-deletes a product if no order items reference it (CAT-US3).
+     * Logs the deletion (product snapshot + actor) in a single transaction.
+     *
+     * @throws ResponseStatusException 404 if product not found, 409 if order history exists
+     */
+    @Transactional
+    public void deleteProduct(Long id, User deletedBy) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Product not found with id: " + id));
+
+        if (orderItemRepository.existsByProduct_Id(id)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot delete product with existing order history");
+        }
+
+        ProductDeletionLog log = new ProductDeletionLog();
+        log.setProductIdSnapshot(product.getId());
+        log.setProductCodeSnapshot(product.getProductCode());
+        log.setDescriptionSnapshot(product.getDescription());
+        log.setDeletedBy(deletedBy);
+        log.setDeletedAt(Instant.now());
+        productDeletionLogRepository.save(log);
+
+        productRepository.delete(product);
     }
 }

--- a/backend/src/test/java/com/ipos/cat/CatalogueCatTest.java
+++ b/backend/src/test/java/com/ipos/cat/CatalogueCatTest.java
@@ -1,6 +1,6 @@
 /*
  * ╔══════════════════════════════════════════════════════════════════════════════╗
- * ║  WHAT: Central CAT test source for IPOS-SA-CAT US1 and US2.                ║
+ * ║  WHAT: Central CAT test source for IPOS-SA-CAT US1–US4.                    ║
  * ║                                                                              ║
  * ║  WHY:  Keep catalogue behavior in one file for easier marking/review while   ║
  * ║        following the working style used by MerchantAccountServiceTest:       ║
@@ -12,8 +12,10 @@
  * ║    1) CatalogueCatTest (Mockito unit tests):                                 ║
  * ║       - CAT-US1 initialize/ensure metadata                                   ║
  * ║       - CAT-US2 product create rules                                         ║
+ * ║       - CAT-US3 product delete (audit log, 409 guard, 404)                   ║
+ * ║       - CAT-US4 product update (immutable productCode, 404)                  ║
  * ║    2) ProductControllerCatalogueCatWebMvcTest (WebMvc slice):               ║
- * ║       - DTO validation and successful POST response                          ║
+ * ║       - DTO validation and successful POST/PUT/DELETE responses              ║
  * ╚══════════════════════════════════════════════════════════════════════════════╝
  */
 package com.ipos.cat;
@@ -21,11 +23,18 @@ package com.ipos.cat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ipos.controller.ProductController;
 import com.ipos.dto.CreateProductRequest;
+import com.ipos.dto.UpdateProductRequest;
 import com.ipos.entity.CatalogueMetadata;
 import com.ipos.entity.Product;
+import com.ipos.entity.ProductDeletionLog;
+import com.ipos.entity.User;
 import com.ipos.repository.CatalogueMetadataRepository;
+import com.ipos.repository.OrderItemRepository;
+import com.ipos.repository.ProductDeletionLogRepository;
 import com.ipos.repository.ProductRepository;
+import com.ipos.repository.UserRepository;
 import com.ipos.service.CatalogueService;
+import com.ipos.service.ProductService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,16 +51,21 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
-import java.lang.reflect.Method;
-import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("IPOS-SA-CAT — Catalogue & product (CatalogueCatTest)")
@@ -68,20 +82,21 @@ public class CatalogueCatTest {
     @Mock
     private CatalogueService catalogueServiceMock;
 
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private ProductDeletionLogRepository productDeletionLogRepository;
+
     private CatalogueService catalogueService;
-    private Object productServiceUnderTest;
+    private ProductService productService;
 
     @BeforeEach
     void setUp() {
         catalogueService = new CatalogueService(catalogueMetadataRepository);
-        try {
-            Class<?> clazz = Class.forName("com.ipos.service.ProductService");
-            productServiceUnderTest = clazz
-                    .getConstructor(ProductRepository.class, CatalogueService.class)
-                    .newInstance(productRepository, catalogueServiceMock);
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException("Failed to construct ProductService for tests", e);
-        }
+        productService = new ProductService(
+                productRepository, catalogueServiceMock,
+                orderItemRepository, productDeletionLogRepository);
     }
 
     private static CreateProductRequest newCreateRequest(String code, String desc, String price, int avail) {
@@ -93,24 +108,27 @@ public class CatalogueCatTest {
         return r;
     }
 
-    private Product invokeCreateProduct(CreateProductRequest request) {
-        try {
-            Method method = productServiceUnderTest.getClass()
-                    .getMethod("createProduct", CreateProductRequest.class);
-            return (Product) method.invoke(productServiceUnderTest, request);
-        } catch (InvocationTargetException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof ResponseStatusException rse) {
-                throw rse;
-            }
-            throw new RuntimeException("Failed to invoke ProductService#createProduct", e);
-        } catch (ReflectiveOperationException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof ResponseStatusException rse) {
-                throw rse;
-            }
-            throw new RuntimeException("Failed to invoke ProductService#createProduct", e);
-        }
+    private static UpdateProductRequest newUpdateRequest(String desc, String price, int avail) {
+        UpdateProductRequest r = new UpdateProductRequest();
+        r.setDescription(desc);
+        r.setPrice(new BigDecimal(price));
+        r.setAvailabilityCount(avail);
+        return r;
+    }
+
+    private static Product sampleProduct(Long id, String code, String desc, String price, int avail) {
+        Product p = new Product(code, desc, new BigDecimal(price), avail);
+        p.setId(id);
+        return p;
+    }
+
+    private static User sampleAdmin() {
+        User u = new User();
+        u.setId(99L);
+        u.setUsername("admin");
+        u.setName("Admin");
+        u.setRole(User.Role.ADMIN);
+        return u;
     }
 
     // ═════════════════════════════════════════════════════════════════════════
@@ -161,7 +179,7 @@ public class CatalogueCatTest {
         when(productRepository.existsByProductCode("ABC-001")).thenReturn(false);
         when(productRepository.save(any(Product.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        Product out = invokeCreateProduct(
+        Product out = productService.createProduct(
                 newCreateRequest("  abc-001  ", "Aspirin", "9.99", 12));
 
         assertEquals("ABC-001", out.getProductCode());
@@ -176,7 +194,7 @@ public class CatalogueCatTest {
         when(productRepository.existsByProductCode("DUP")).thenReturn(true);
 
         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-                () -> invokeCreateProduct(newCreateRequest("DUP", "X", "1.00", 1)));
+                () -> productService.createProduct(newCreateRequest("DUP", "X", "1.00", 1)));
         assertEquals(409, ex.getStatusCode().value());
         verify(productRepository, never()).save(any());
     }
@@ -186,7 +204,7 @@ public class CatalogueCatTest {
     void createProduct_blankCode_badRequest() {
         CreateProductRequest r = newCreateRequest("   ", "X", "1.00", 1);
         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-                () -> invokeCreateProduct(r));
+                () -> productService.createProduct(r));
         assertEquals(400, ex.getStatusCode().value());
     }
 
@@ -196,7 +214,7 @@ public class CatalogueCatTest {
         when(productRepository.existsByProductCode("X")).thenReturn(false);
         when(productRepository.save(any(Product.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        Product out = invokeCreateProduct(
+        Product out = productService.createProduct(
                 newCreateRequest("x", "  trimmed  ", "2.50", 0));
 
         assertEquals("trimmed", out.getDescription());
@@ -209,7 +227,7 @@ public class CatalogueCatTest {
         when(productRepository.existsByProductCode("P1")).thenReturn(false);
         when(productRepository.save(any(Product.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        invokeCreateProduct(newCreateRequest("p1", "Item", "100.00", 5));
+        productService.createProduct(newCreateRequest("p1", "Item", "100.00", 5));
 
         ArgumentCaptor<Product> cap = ArgumentCaptor.forClass(Product.class);
         verify(productRepository).save(cap.capture());
@@ -218,14 +236,109 @@ public class CatalogueCatTest {
         assertEquals(0, new BigDecimal("100.00").compareTo(saved.getPrice()));
         assertEquals(5, saved.getAvailabilityCount());
     }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    //  CAT-US3: ProductService#deleteProduct rules
+    // ═════════════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("CAT-US3: deleteProduct returns 404 when product not found")
+    void deleteProduct_notFound_404() {
+        when(productRepository.findById(999L)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> productService.deleteProduct(999L, sampleAdmin()));
+        assertEquals(404, ex.getStatusCode().value());
+        verify(productDeletionLogRepository, never()).save(any());
+        verify(productRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("CAT-US3: deleteProduct returns 409 when order items reference product")
+    void deleteProduct_orderHistoryExists_409() {
+        Product product = sampleProduct(1L, "DEL1", "Item", "5.00", 10);
+        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        when(orderItemRepository.existsByProduct_Id(1L)).thenReturn(true);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> productService.deleteProduct(1L, sampleAdmin()));
+        assertEquals(409, ex.getStatusCode().value());
+        verify(productDeletionLogRepository, never()).save(any());
+        verify(productRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("CAT-US3: deleteProduct succeeds, saves audit log with actor snapshot")
+    void deleteProduct_success_logsAndDeletes() {
+        Product product = sampleProduct(1L, "DEL1", "Aspirin", "5.00", 10);
+        User admin = sampleAdmin();
+        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        when(orderItemRepository.existsByProduct_Id(1L)).thenReturn(false);
+
+        productService.deleteProduct(1L, admin);
+
+        ArgumentCaptor<ProductDeletionLog> logCap = ArgumentCaptor.forClass(ProductDeletionLog.class);
+        verify(productDeletionLogRepository).save(logCap.capture());
+        ProductDeletionLog savedLog = logCap.getValue();
+        assertEquals(1L, savedLog.getProductIdSnapshot());
+        assertEquals("DEL1", savedLog.getProductCodeSnapshot());
+        assertEquals("Aspirin", savedLog.getDescriptionSnapshot());
+        assertEquals(admin, savedLog.getDeletedBy());
+        assertNotNull(savedLog.getDeletedAt());
+
+        verify(productRepository).delete(product);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    //  CAT-US4: ProductService#updateProduct rules
+    // ═════════════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("CAT-US4: updateProduct returns 404 when product not found")
+    void updateProduct_notFound_404() {
+        when(productRepository.findById(999L)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> productService.updateProduct(999L, newUpdateRequest("X", "1.00", 1)));
+        assertEquals(404, ex.getStatusCode().value());
+        verify(productRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("CAT-US4: updateProduct updates fields but never changes productCode")
+    void updateProduct_success_immutableCode() {
+        Product existing = sampleProduct(1L, "ORIG-CODE", "Old desc", "5.00", 10);
+        when(productRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(productRepository.save(any(Product.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Product result = productService.updateProduct(1L,
+                newUpdateRequest("New desc", "12.50", 20));
+
+        assertEquals("ORIG-CODE", result.getProductCode());
+        assertEquals("New desc", result.getDescription());
+        assertEquals(0, new BigDecimal("12.50").compareTo(result.getPrice()));
+        assertEquals(20, result.getAvailabilityCount());
+    }
+
+    @Test
+    @DisplayName("CAT-US4: updateProduct trims description whitespace")
+    void updateProduct_trimsDescription() {
+        Product existing = sampleProduct(1L, "X", "Old", "1.00", 1);
+        when(productRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(productRepository.save(any(Product.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Product result = productService.updateProduct(1L,
+                newUpdateRequest("  padded  ", "2.00", 5));
+
+        assertEquals("padded", result.getDescription());
+    }
 }
 
 /*
  * WebMvc slice — same source file as CatalogueCatTest; Surefire discovers *Test classes.
  */
 @WebMvcTest(controllers = ProductController.class)
-@AutoConfigureMockMvc(addFilters = false)
-@DisplayName("ProductController — WebMvc slice (CAT-US2)")
+@DisplayName("ProductController — WebMvc slice (CAT-US2/US3/US4)")
 @SuppressWarnings({"null", "unused"})
 class ProductControllerCatalogueCatWebMvcTest {
 
@@ -236,12 +349,19 @@ class ProductControllerCatalogueCatWebMvcTest {
     private ObjectMapper objectMapper;
 
     @MockitoBean
-    private com.ipos.service.ProductService productService;
+    private ProductService productService;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    // ── CAT-US2: POST ───────────────────────────────────────────────────────
 
     @Test
     @DisplayName("POST /api/products with {} → 400 Bad Request (validation)")
     void create_emptyBody_returns400() throws Exception {
         mockMvc.perform(post("/api/products")
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(status().isBadRequest());
@@ -259,8 +379,61 @@ class ProductControllerCatalogueCatWebMvcTest {
         Product saved = new Product("SKU1", "Item", new BigDecimal("10.00"), 3);
         saved.setId(42L);
         mockMvc.perform(post("/api/products")
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk());
+    }
+
+    // ── CAT-US4: PUT ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("PUT /api/products/1 with {} → 400 Bad Request (validation)")
+    void update_emptyBody_returns400() throws Exception {
+        mockMvc.perform(put("/api/products/1")
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PUT /api/products/1 with valid body → 200")
+    void update_valid_returns200() throws Exception {
+        UpdateProductRequest req = new UpdateProductRequest();
+        req.setDescription("Updated");
+        req.setPrice(new BigDecimal("15.00"));
+        req.setAvailabilityCount(10);
+
+        Product updated = new Product("X", "Updated", new BigDecimal("15.00"), 10);
+        updated.setId(1L);
+        when(productService.updateProduct(eq(1L), any(UpdateProductRequest.class))).thenReturn(updated);
+
+        mockMvc.perform(put("/api/products/1")
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+
+    // ── CAT-US3: DELETE ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("DELETE /api/products/1 → 204 No Content (mocked service)")
+    void delete_success_returns204() throws Exception {
+        User admin = new User();
+        admin.setId(1L);
+        admin.setUsername("admin");
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+
+        mockMvc.perform(delete("/api/products/1")
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+
+        verify(productService).deleteProduct(eq(1L), any(User.class));
     }
 }

--- a/frontend/src/Catalogue.jsx
+++ b/frontend/src/Catalogue.jsx
@@ -1,14 +1,13 @@
 /*
- * ╔══════════════════════════════════════════════════════════════════════════════╗
- * ║  WHAT: Product catalogue — list, CAT-US1 initialize, CAT-US2 admin create.   ║
- * ║                                                                              ║
- * ║  WHY:  Read-only table for all roles; ADMIN gets initialize + add product.   ║
- * ╚══════════════════════════════════════════════════════════════════════════════╝
+ * Product catalogue — list, CAT-US1 initialize, CAT-US2 admin create,
+ * CAT-US3 admin delete (Yes/No modal), CAT-US4 admin edit.
  */
 import { useState, useEffect, useCallback } from "react";
 import {
   getProducts,
   createProduct,
+  updateProduct,
+  deleteProduct,
   getCatalogueStatus,
   initializeCatalogue,
 } from "./api.js";
@@ -34,6 +33,17 @@ function Catalogue() {
   });
   const [createBusy, setCreateBusy] = useState(false);
   const [createMessage, setCreateMessage] = useState(null);
+
+  // CAT-US4: Edit state
+  const [editingProduct, setEditingProduct] = useState(null);
+  const [editForm, setEditForm] = useState({ description: "", price: "", availabilityCount: "" });
+  const [editBusy, setEditBusy] = useState(false);
+  const [editMessage, setEditMessage] = useState(null);
+
+  // CAT-US3: Delete confirmation modal state
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [deleteMessage, setDeleteMessage] = useState(null);
 
   const loadProducts = useCallback(async () => {
     const data = await getProducts();
@@ -102,6 +112,67 @@ function Catalogue() {
       setCreateMessage(err.message);
     } finally {
       setCreateBusy(false);
+    }
+  };
+
+  // CAT-US4: Start editing a product row
+  const startEdit = (product) => {
+    setEditingProduct(product);
+    setEditForm({
+      description: product.description || "",
+      price: product.price != null ? String(product.price) : "",
+      availabilityCount: product.availabilityCount != null ? String(product.availabilityCount) : "0",
+    });
+    setEditMessage(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingProduct(null);
+    setEditMessage(null);
+  };
+
+  const handleUpdateProduct = async (e) => {
+    e.preventDefault();
+    setEditBusy(true);
+    setEditMessage(null);
+    try {
+      await updateProduct(editingProduct.id, {
+        description: editForm.description.trim(),
+        price: Number(editForm.price),
+        availabilityCount: parseInt(editForm.availabilityCount, 10),
+      });
+      setEditingProduct(null);
+      setEditMessage(null);
+      await loadProducts();
+    } catch (err) {
+      setEditMessage(err.message);
+    } finally {
+      setEditBusy(false);
+    }
+  };
+
+  // CAT-US3: Delete with Yes/No confirmation
+  const confirmDelete = (product) => {
+    setDeleteTarget(product);
+    setDeleteMessage(null);
+  };
+
+  const cancelDelete = () => {
+    setDeleteTarget(null);
+    setDeleteMessage(null);
+  };
+
+  const handleDeleteProduct = async () => {
+    setDeleteBusy(true);
+    setDeleteMessage(null);
+    try {
+      await deleteProduct(deleteTarget.id);
+      setDeleteTarget(null);
+      await loadProducts();
+    } catch (err) {
+      setDeleteMessage(err.message);
+    } finally {
+      setDeleteBusy(false);
     }
   };
 
@@ -238,19 +309,185 @@ function Catalogue() {
               <th>Description</th>
               <th>Price</th>
               <th>In Stock</th>
+              {isAdmin && <th>Actions</th>}
             </tr>
           </thead>
           <tbody>
             {products.map((product) => (
               <tr key={product.id}>
-                <td>{product.productCode ?? "—"}</td>
+                <td>{product.productCode ?? "\u2014"}</td>
                 <td>{product.description}</td>
-                <td>£{Number(product.price).toFixed(2)}</td>
+                <td>&pound;{Number(product.price).toFixed(2)}</td>
                 <td>{product.availabilityCount}</td>
+                {isAdmin && (
+                  <td>
+                    <button
+                      type="button"
+                      className="submit-btn"
+                      style={{ marginRight: "0.5rem", padding: "0.25rem 0.75rem", fontSize: "0.85rem" }}
+                      onClick={() => startEdit(product)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      className="submit-btn"
+                      style={{ padding: "0.25rem 0.75rem", fontSize: "0.85rem", background: "#dc2626" }}
+                      onClick={() => confirmDelete(product)}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>
         </table>
+      )}
+
+      {/* CAT-US4: Edit product modal */}
+      {editingProduct && (
+        <div
+          style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: "rgba(0,0,0,0.4)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 1000,
+          }}
+          onClick={cancelEdit}
+        >
+          <div
+            style={{
+              background: "#fff",
+              borderRadius: "8px",
+              padding: "1.5rem",
+              minWidth: "340px",
+              maxWidth: "480px",
+              boxShadow: "0 4px 24px rgba(0,0,0,0.2)",
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 style={{ marginTop: 0 }}>
+              Edit Product: {editingProduct.productCode ?? editingProduct.id}
+            </h3>
+            <form onSubmit={handleUpdateProduct}>
+              <div className="form-group">
+                <label htmlFor="edit-description">Description</label>
+                <input
+                  id="edit-description"
+                  value={editForm.description}
+                  onChange={(e) => setEditForm((f) => ({ ...f, description: e.target.value }))}
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="edit-price">Unit price</label>
+                <input
+                  id="edit-price"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  value={editForm.price}
+                  onChange={(e) => setEditForm((f) => ({ ...f, price: e.target.value }))}
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="edit-availability">Availability</label>
+                <input
+                  id="edit-availability"
+                  type="number"
+                  min="0"
+                  value={editForm.availabilityCount}
+                  onChange={(e) => setEditForm((f) => ({ ...f, availabilityCount: e.target.value }))}
+                  required
+                />
+              </div>
+              {editMessage && (
+                <p className="status-message error" style={{ marginBottom: "0.75rem" }}>
+                  {editMessage}
+                </p>
+              )}
+              <div style={{ display: "flex", gap: "0.75rem", justifyContent: "flex-end" }}>
+                <button type="button" className="submit-btn" style={{ background: "#64748b" }} onClick={cancelEdit}>
+                  Cancel
+                </button>
+                <button type="submit" className="submit-btn" disabled={editBusy}>
+                  {editBusy ? "Saving..." : "Save changes"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* CAT-US3: Delete confirmation modal (Yes / No) */}
+      {deleteTarget && (
+        <div
+          style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: "rgba(0,0,0,0.4)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 1000,
+          }}
+          onClick={cancelDelete}
+        >
+          <div
+            style={{
+              background: "#fff",
+              borderRadius: "8px",
+              padding: "1.5rem",
+              minWidth: "320px",
+              maxWidth: "440px",
+              boxShadow: "0 4px 24px rgba(0,0,0,0.2)",
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 style={{ marginTop: 0 }}>Confirm Deletion</h3>
+            <p>
+              Are you sure you want to delete product{" "}
+              <strong>{deleteTarget.productCode ?? deleteTarget.id}</strong>
+              {deleteTarget.description ? ` (${deleteTarget.description})` : ""}?
+            </p>
+            {deleteMessage && (
+              <p className="status-message error" style={{ marginBottom: "0.75rem" }}>
+                {deleteMessage}
+              </p>
+            )}
+            <div style={{ display: "flex", gap: "0.75rem", justifyContent: "flex-end" }}>
+              <button
+                type="button"
+                className="submit-btn"
+                style={{ background: "#64748b" }}
+                onClick={cancelDelete}
+                disabled={deleteBusy}
+              >
+                No
+              </button>
+              <button
+                type="button"
+                className="submit-btn"
+                style={{ background: "#dc2626" }}
+                onClick={handleDeleteProduct}
+                disabled={deleteBusy}
+              >
+                {deleteBusy ? "Deleting..." : "Yes"}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -90,6 +90,44 @@ export async function createProduct(product) {
   return body;
 }
 
+/**
+ * Update an existing product (CAT-US4).
+ * PUT /api/products/{id} with description, price, availabilityCount.
+ *
+ * ACCESS: ADMIN only.
+ */
+export async function updateProduct(id, product) {
+  const response = await fetchWithAuth(`${API_BASE}/products/${id}`, {
+    method: "PUT",
+    body: JSON.stringify({
+      description: product.description,
+      price: product.price,
+      availabilityCount: product.availabilityCount,
+    }),
+  });
+  const body = await parseResponseBody(response);
+  if (!response.ok) {
+    throw new Error(errorMessageFromBody(body, response));
+  }
+  return body;
+}
+
+/**
+ * Delete a product (CAT-US3).
+ * DELETE /api/products/{id}.
+ *
+ * ACCESS: ADMIN only.
+ */
+export async function deleteProduct(id) {
+  const response = await fetchWithAuth(`${API_BASE}/products/${id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    const body = await parseResponseBody(response);
+    throw new Error(errorMessageFromBody(body, response));
+  }
+}
+
 /* ── Catalogue (CAT-US1) ─────────────────────────────────────────────────── */
 
 /**


### PR DESCRIPTION
Backend:
- ProductDeletionLog entity + repository (audit trail for deletions)
- OrderItemRepository.existsByProduct_Id() for delete guard
- UpdateProductRequest DTO (description, price, availability; productCode immutable)
- ProductService.updateProduct() and deleteProduct() — both @Transactional; deleteProduct returns 409 if order history exists, logs actor + snapshot
- ProductController PUT/{id} and DELETE/{id} (ADMIN only; Authentication param injection)

Frontend:
- api.js: updateProduct() and deleteProduct()
- Catalogue.jsx: Edit modal (prefilled form, saves via PUT) and Yes/No delete confirmation modal; Actions column visible to ADMIN only

Tests:
- CatalogueCatTest extended with 5 new Mockito unit tests (CAT-US3/US4)
- WebMvc slice updated: PUT validation + happy path, DELETE 204 with security

Docs:
- CATprogress.txt: US3 and US4 marked DONE with implementation notes
- README.md: updated package status, endpoint table, and test counts
- CLAUDE.md: updated with codebase guidance