### PR TITLE
Testing package: JUnit suite, ProductService tests, JDK 25 test fix (supersedes #20)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -130,6 +130,16 @@
         </dependency>
 
         <!--
+            junit-platform-suite
+            Enables @Suite / @SelectClasses in IposTestSuite (batch run for the Implementation Report).
+        -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
             spring-security-test
             Provides test utilities for Spring Security: @WithMockUser,
             SecurityMockMvcRequestPostProcessors (csrf(), user()), and

--- a/backend/src/test/java/com/ipos/IposTestSuite.java
+++ b/backend/src/test/java/com/ipos/IposTestSuite.java
@@ -1,0 +1,33 @@
+/*
+ * ╔══════════════════════════════════════════════════════════════════════════════╗
+ * ║  WHAT: JUnit Platform suite — runs core IPOS-SA test classes in one batch.   ║
+ * ║                                                                              ║
+ * ║  WHY:  Brief asks for a test suite; this aggregates ACC, CAT, and ORD tests  ║
+ * ║        already on main plus the dedicated ProductServiceTest in this PR.     ║
+ * ║                                                                              ║
+ * ║  HOW TO RUN:                                                                 ║
+ * ║        cd backend && mvn test                                                  ║
+ * ║        mvn test -Dtest=IposTestSuite                                           ║
+ * ║        Run this class from the IDE to execute the suite only.                 ║
+ * ╚══════════════════════════════════════════════════════════════════════════════╝
+ */
+package com.ipos;
+
+import com.ipos.cat.CatalogueCatTest;
+import com.ipos.ord.ORDInvoicePaymentTest;
+import com.ipos.ord.ORDOrderTest;
+import com.ipos.service.MerchantAccountServiceTest;
+import com.ipos.service.ProductServiceTest;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({
+        MerchantAccountServiceTest.class,
+        ProductServiceTest.class,
+        CatalogueCatTest.class,
+        ORDOrderTest.class,
+        ORDInvoicePaymentTest.class
+})
+public class IposTestSuite {
+}

--- a/backend/src/test/java/com/ipos/service/MerchantAccountServiceTest.java
+++ b/backend/src/test/java/com/ipos/service/MerchantAccountServiceTest.java
@@ -76,7 +76,7 @@ import static org.mockito.Mockito.*;
  * tests start in milliseconds.
  */
 @ExtendWith(MockitoExtension.class)
-class MerchantAccountServiceTest {
+public class MerchantAccountServiceTest {
 
     /* ── Mocked dependencies ──────────────────────────────────────────────── */
 

--- a/backend/src/test/java/com/ipos/service/ProductServiceTest.java
+++ b/backend/src/test/java/com/ipos/service/ProductServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ * ╔══════════════════════════════════════════════════════════════════════════════╗
+ * ║  WHAT: JUnit 5 unit tests for ProductService (IPOS-SA-CAT) — service layer.  ║
+ * ║                                                                              ║
+ * ║  WHY:  Complements {@link com.ipos.cat.CatalogueCatTest} (CAT-US1–US10) by   ║
+ * ║        exercising {@link ProductService} entry points that are not covered  ║
+ * ║        elsewhere: {@code findAll}, {@code findById}, {@code getLowStockProducts}. ║
+ * ║        Together with MerchantAccountServiceTest this satisfies the brief’s   ║
+ * ║        “two non-trivial classes with unit tests” requirement.                ║
+ * ╚══════════════════════════════════════════════════════════════════════════════╝
+ */
+package com.ipos.service;
+
+import com.ipos.dto.LowStockProductDto;
+import com.ipos.entity.Product;
+import com.ipos.repository.CatalogueMetadataRepository;
+import com.ipos.repository.OrderItemRepository;
+import com.ipos.repository.ProductDeletionLogRepository;
+import com.ipos.repository.ProductRepository;
+import com.ipos.repository.StockDeliveryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private CatalogueMetadataRepository catalogueMetadataRepository;
+
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private ProductDeletionLogRepository productDeletionLogRepository;
+
+    @Mock
+    private StockDeliveryRepository stockDeliveryRepository;
+
+    private ProductService productService;
+
+    @BeforeEach
+    void setUp() {
+        CatalogueService catalogueService = new CatalogueService(catalogueMetadataRepository);
+        productService = new ProductService(
+                productRepository,
+                catalogueService,
+                orderItemRepository,
+                productDeletionLogRepository,
+                stockDeliveryRepository);
+    }
+
+    private static Product product(long id, String code, int stock) {
+        Product p = new Product(code, "Desc", new BigDecimal("9.99"), stock);
+        p.setId(id);
+        return p;
+    }
+
+    @Test
+    @DisplayName("T12 findAll: catalogue has items — returns non-empty list")
+    void findAll_withItems_returnsNonEmpty() {
+        when(productRepository.findAll()).thenReturn(List.of(product(1L, "A", 1), product(2L, "B", 2)));
+
+        List<Product> result = productService.findAll();
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    @DisplayName("T13 findAll: empty repository — empty list (not null)")
+    void findAll_empty_returnsEmptyNotNull() {
+        when(productRepository.findAll()).thenReturn(Collections.emptyList());
+
+        List<Product> result = productService.findAll();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("findById: existing product — returned")
+    void findById_found_returnsProduct() {
+        Product p = product(10L, "SKU", 5);
+        when(productRepository.findById(10L)).thenReturn(Optional.of(p));
+
+        Product result = productService.findById(10L);
+
+        assertEquals(10L, result.getId());
+        assertEquals("SKU", result.getProductCode());
+    }
+
+    @Test
+    @DisplayName("findById: missing id — 404 ResponseStatusException")
+    void findById_missing_throws404() {
+        when(productRepository.findById(999L)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> productService.findById(999L));
+
+        assertEquals(404, ex.getStatusCode().value());
+    }
+
+    @Test
+    @DisplayName("getLowStockProducts: maps repository low-stock rows to DTOs")
+    void getLowStockProducts_delegatesToRepository() {
+        Product low = product(1L, "LOW", 2);
+        low.setMinStockThreshold(10);
+        when(productRepository.findLowStockProducts()).thenReturn(List.of(low));
+
+        List<LowStockProductDto> dtos = productService.getLowStockProducts();
+
+        assertEquals(1, dtos.size());
+        assertEquals("LOW", dtos.get(0).getProductCode());
+    }
+
+    @Test
+    @DisplayName("getLowStockProducts: none low — empty list")
+    void getLowStockProducts_none_empty() {
+        when(productRepository.findLowStockProducts()).thenReturn(Collections.emptyList());
+
+        assertTrue(productService.getLowStockProducts().isEmpty());
+    }
+}

--- a/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
## Overview
Supersedes the closed PR #20 after `main` moved forward (ORD/CAT features merged). This PR adds **test-only** changes on top of current `PharmaLogitech/team-proj:main`: a JUnit batch suite, additional `ProductService` unit tests, and a test-scoped Mockito/JDK 25 fix so existing WebMvc tests keep passing.

**Relation to prior work**
- PR #20 introduced service stubs and tests against older APIs; it was closed without merge.
- Issue #21 is **already closed**; ORD payment/status behaviour on `main` is now covered by the merged ORD epic and existing tests (e.g. `ORDOrderTest`, `ORDInvoicePaymentTest`), not by re-adding stub services here.

## Ticket mapping
- **Closes #22** — [TESTING] Unit/Sub-system/System test package for ACC/CAT/ORD boundary (updated: suite + tests align with **current** `main`; see Scope).
- **Related (already closed, not closed again):** #21 — service contracts were tracked there / superseded by merged ORD work on `main`.

## Scope delivered (tests / build for tests only)
- **Unit tests:** `MerchantAccountServiceTest` (made `public` for suite discovery), **new** `ProductServiceTest` (`findAll`, `findById`, `getLowStockProducts`).
- **Sub-system / integration-style tests:** unchanged on `main` — **included in batch suite:** `CatalogueCatTest`, `ORDOrderTest`, `ORDInvoicePaymentTest` (these already satisfy ORD/CAT coverage; they replace the old `OrderServiceTest` / `PaymentServiceTest` that targeted removed APIs).
- **System / email boundary:** No `EmailService` on current `main`; email is not reintroduced here (tests-only PR). Brief “system” coverage is represented by existing boundaries elsewhere as implemented on `main`.
- **Suite:** `IposTestSuite` runs the classes above in one batch.
- **Supporting (test classpath):** `junit-platform-suite` in `pom.xml` (test scope); `mockito-extensions` **mock-maker-subclass** for JDK 25 + `@MockitoBean` on `ProductService` in WebMvc tests.

No changes under `src/main/java`.

## Verification
```bash
cd backend && mvn test "-Dspring.profiles.active=test"
```

## AI usage disclosure
AI tooling was used for test scaffolding, suite wiring, and the JDK 25 Mockito workaround. Outputs were reviewed and validated with local `mvn test` before opening this PR.
