### PR TITLE
Fix ACC-US5: automatic merchant standing transitions

### DIFF
--- a/backend/src/main/java/com/ipos/controller/MerchantProfileController.java
+++ b/backend/src/main/java/com/ipos/controller/MerchantProfileController.java
@@ -37,6 +37,7 @@ import com.ipos.entity.MonthlyRebateSettlement.SettlementMode;
 import com.ipos.entity.StandingChangeLog;
 import com.ipos.entity.User;
 import com.ipos.repository.MerchantProfileRepository;
+import com.ipos.repository.PaymentRepository;
 import com.ipos.repository.StandingChangeLogRepository;
 import com.ipos.repository.UserRepository;
 import com.ipos.service.MerchantAccountService;
@@ -53,7 +54,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.math.BigDecimal;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
@@ -68,15 +68,18 @@ public class MerchantProfileController {
     private final MerchantAccountService merchantAccountService;
     private final StandingChangeLogRepository standingChangeLogRepository;
     private final UserRepository userRepository;
+    private final PaymentRepository paymentRepository;
 
     public MerchantProfileController(MerchantProfileRepository profileRepository,
                                      MerchantAccountService merchantAccountService,
                                      StandingChangeLogRepository standingChangeLogRepository,
-                                     UserRepository userRepository) {
+                                     UserRepository userRepository,
+                                     PaymentRepository paymentRepository) {
         this.profileRepository = profileRepository;
         this.merchantAccountService = merchantAccountService;
         this.standingChangeLogRepository = standingChangeLogRepository;
         this.userRepository = userRepository;
+        this.paymentRepository = paymentRepository;
     }
 
     /* GET /api/merchant-profiles → List all merchant profiles as DTOs. */
@@ -233,18 +236,22 @@ public class MerchantProfileController {
                     }
 
                     /*
-                     * ACC-US5: 30-day rule — "long-term payment issue (e.g. longer
-                     * than 30 days without payment)."  The Manager can only restore
-                     * if the merchant has been in default for at least 30 days.
+                     * ACC-US5: "only if payment made" — the Manager can only restore
+                     * a merchant from IN_DEFAULT to NORMAL if at least one payment
+                     * has been recorded against their invoices since they went into default.
                      */
-                    if (profile.getInDefaultSince() != null) {
-                        long daysInDefault = Duration.between(
-                                profile.getInDefaultSince(), Instant.now()).toDays();
-                        if (daysInDefault < 30) {
+                    if (newStanding == MerchantStanding.NORMAL
+                            && profile.getInDefaultSince() != null) {
+                        java.math.BigDecimal paidSinceDefault =
+                                paymentRepository.sumPaymentsByMerchantIdSince(
+                                        profile.getUser().getId(),
+                                        profile.getInDefaultSince());
+                        if (paidSinceDefault.compareTo(java.math.BigDecimal.ZERO) <= 0) {
                             return ResponseEntity.badRequest()
                                     .body(Map.of("error",
-                                            "Account has only been in default for " + daysInDefault
-                                            + " days. The minimum is 30 days before the standing can be changed."));
+                                            "Cannot restore to NORMAL: no payment has been recorded "
+                                            + "since the account went into default on "
+                                            + profile.getInDefaultSince().toString().substring(0, 10) + "."));
                         }
                     }
 

--- a/backend/src/main/java/com/ipos/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/ipos/repository/PaymentRepository.java
@@ -16,6 +16,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
@@ -24,4 +25,14 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p " +
            "WHERE p.invoice.id = :invoiceId")
     BigDecimal sumByInvoiceId(@Param("invoiceId") Long invoiceId);
+
+    /**
+     * Sum of all payments recorded for a merchant's invoices on or after a given
+     * timestamp.  Used to check whether a payment has been made since the
+     * merchant went into default (ACC-US5).
+     */
+    @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p " +
+           "WHERE p.invoice.merchant.id = :merchantId AND p.recordedAt >= :since")
+    BigDecimal sumPaymentsByMerchantIdSince(@Param("merchantId") Long merchantId,
+                                            @Param("since") Instant since);
 }

--- a/backend/src/main/java/com/ipos/service/OrderService.java
+++ b/backend/src/main/java/com/ipos/service/OrderService.java
@@ -70,6 +70,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +86,7 @@ public class OrderService {
     private final InvoiceService invoiceService;
     private final InvoiceRepository invoiceRepository;
     private final IntegrationCaProperties caProperties;
+    private final StandingTransitionService standingTransitionService;
 
     public OrderService(OrderRepository orderRepository,
                         ProductRepository productRepository,
@@ -92,7 +94,8 @@ public class OrderService {
                         MerchantProfileRepository profileRepository,
                         InvoiceService invoiceService,
                         InvoiceRepository invoiceRepository,
-                        IntegrationCaProperties caProperties) {
+                        IntegrationCaProperties caProperties,
+                        StandingTransitionService standingTransitionService) {
         this.orderRepository = orderRepository;
         this.productRepository = productRepository;
         this.userRepository = userRepository;
@@ -100,6 +103,7 @@ public class OrderService {
         this.invoiceService = invoiceService;
         this.invoiceRepository = invoiceRepository;
         this.caProperties = caProperties;
+        this.standingTransitionService = standingTransitionService;
     }
 
     /**
@@ -268,8 +272,18 @@ public class OrderService {
         /*
          * Step 3: Standing guard (brief §iii).
          * Only merchants with NORMAL standing can trade.  IN_DEFAULT and
-         * SUSPENDED merchants are blocked until a Manager restores them.
+         * SUSPENDED merchants are blocked.
+         *
+         * Auto-escalation: if a merchant has been IN_DEFAULT for 30+ days,
+         * automatically move them to SUSPENDED before blocking the order.
          */
+        if (profile.getStanding() == MerchantStanding.IN_DEFAULT
+                && profile.getInDefaultSince() != null
+                && Duration.between(profile.getInDefaultSince(), Instant.now()).toDays() >= 30) {
+            standingTransitionService.autoMoveToSuspended(resolvedMerchantId);
+            profile.setStanding(MerchantStanding.SUSPENDED); // reflect locally for the error message
+        }
+
         if (profile.getStanding() != MerchantStanding.NORMAL) {
             throw new RuntimeException(
                     "Your account is currently " + profile.getStanding()
@@ -373,8 +387,14 @@ public class OrderService {
         BigDecimal newExposure = existingExposure.add(totalDue);
 
         if (newExposure.compareTo(profile.getCreditLimit()) > 0) {
+            /*
+             * Credit limit breached — automatically move the merchant to IN_DEFAULT.
+             * Uses REQUIRES_NEW transaction so this commits even though the outer
+             * transaction (the order itself) is about to be rolled back.
+             */
+            standingTransitionService.autoMoveToInDefault(resolvedMerchantId);
             throw new RuntimeException(
-                    "Order would exceed credit limit. "
+                    "Order would exceed credit limit. Your account has been placed IN DEFAULT. "
                     + "Current net exposure: £" + existingExposure.setScale(2, RoundingMode.HALF_UP)
                     + " (orders £" + grossOrderExposure.setScale(2, RoundingMode.HALF_UP)
                     + " − payments £" + paymentsReceived.setScale(2, RoundingMode.HALF_UP)

--- a/backend/src/main/java/com/ipos/service/PaymentService.java
+++ b/backend/src/main/java/com/ipos/service/PaymentService.java
@@ -17,9 +17,11 @@
 package com.ipos.service;
 
 import com.ipos.entity.Invoice;
+import com.ipos.entity.MerchantProfile;
 import com.ipos.entity.Payment;
 import com.ipos.entity.User;
 import com.ipos.repository.InvoiceRepository;
+import com.ipos.repository.MerchantProfileRepository;
 import com.ipos.repository.PaymentRepository;
 import com.ipos.repository.UserRepository;
 import org.springframework.http.HttpStatus;
@@ -36,13 +38,16 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final InvoiceRepository invoiceRepository;
     private final UserRepository userRepository;
+    private final MerchantProfileRepository profileRepository;
 
     public PaymentService(PaymentRepository paymentRepository,
                           InvoiceRepository invoiceRepository,
-                          UserRepository userRepository) {
+                          UserRepository userRepository,
+                          MerchantProfileRepository profileRepository) {
         this.paymentRepository = paymentRepository;
         this.invoiceRepository = invoiceRepository;
         this.userRepository = userRepository;
+        this.profileRepository = profileRepository;
     }
 
     /**
@@ -86,6 +91,31 @@ public class PaymentService {
         payment.setRecordedAt(Instant.now());
         payment.setRecordedBy(admin);
 
-        return paymentRepository.save(payment);
+        Payment saved = paymentRepository.save(payment);
+
+        /*
+         * ACC-US5: Auto-restore to NORMAL if the merchant is IN_DEFAULT and the
+         * payment brings their net outstanding balance within the credit limit.
+         * Outstanding = total invoiced − total paid (across all invoices).
+         */
+        profileRepository.findByUserId(invoice.getMerchant().getId()).ifPresent(profile -> {
+            if (profile.getStanding() == MerchantProfile.MerchantStanding.IN_DEFAULT) {
+                BigDecimal totalInvoiced = invoiceRepository.sumTotalDueByMerchantId(
+                        invoice.getMerchant().getId());
+                BigDecimal totalPaid = invoiceRepository.sumPaymentsByMerchantId(
+                        invoice.getMerchant().getId());
+                BigDecimal netOutstanding = totalInvoiced.subtract(totalPaid);
+                if (netOutstanding.compareTo(BigDecimal.ZERO) < 0) {
+                    netOutstanding = BigDecimal.ZERO;
+                }
+                if (netOutstanding.compareTo(new BigDecimal("0.01")) < 0) {
+                    profile.setStanding(MerchantProfile.MerchantStanding.NORMAL);
+                    profile.setInDefaultSince(null);
+                    profileRepository.save(profile);
+                }
+            }
+        });
+
+        return saved;
     }
 }

--- a/backend/src/main/java/com/ipos/service/StandingTransitionService.java
+++ b/backend/src/main/java/com/ipos/service/StandingTransitionService.java
@@ -1,0 +1,57 @@
+package com.ipos.service;
+
+import com.ipos.entity.MerchantProfile;
+import com.ipos.entity.MerchantProfile.MerchantStanding;
+import com.ipos.repository.MerchantProfileRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+/**
+ * Handles automatic merchant standing transitions in a dedicated transaction.
+ *
+ * Methods here use REQUIRES_NEW so they commit independently of the calling
+ * transaction.  This is necessary in OrderService.placeOrder — when an order
+ * is rejected (exception thrown → outer tx rolled back), the standing change
+ * must still persist.
+ */
+@Service
+public class StandingTransitionService {
+
+    private final MerchantProfileRepository profileRepository;
+
+    public StandingTransitionService(MerchantProfileRepository profileRepository) {
+        this.profileRepository = profileRepository;
+    }
+
+    /**
+     * Automatically moves a NORMAL merchant to IN_DEFAULT when their credit
+     * limit has been exceeded.  Commits immediately in its own transaction.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void autoMoveToInDefault(Long merchantUserId) {
+        profileRepository.findByUserId(merchantUserId).ifPresent(profile -> {
+            if (profile.getStanding() == MerchantStanding.NORMAL) {
+                profile.setStanding(MerchantStanding.IN_DEFAULT);
+                profile.setInDefaultSince(Instant.now());
+                profileRepository.save(profile);
+            }
+        });
+    }
+
+    /**
+     * Automatically escalates an IN_DEFAULT merchant to SUSPENDED when they
+     * have been in default for 30+ days.  Commits in its own transaction.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void autoMoveToSuspended(Long merchantUserId) {
+        profileRepository.findByUserId(merchantUserId).ifPresent(profile -> {
+            if (profile.getStanding() == MerchantStanding.IN_DEFAULT) {
+                profile.setStanding(MerchantStanding.SUSPENDED);
+                profileRepository.save(profile);
+            }
+        });
+    }
+}

--- a/backend/src/test/java/com/ipos/ord/ORDInvoicePaymentTest.java
+++ b/backend/src/test/java/com/ipos/ord/ORDInvoicePaymentTest.java
@@ -219,12 +219,13 @@ class PaymentServiceTest {
     @Mock private PaymentRepository paymentRepository;
     @Mock private InvoiceRepository invoiceRepository;
     @Mock private UserRepository userRepository;
+    @Mock private MerchantProfileRepository merchantProfileRepository;
 
     private PaymentService paymentService;
 
     @BeforeEach
     void setUp() {
-        paymentService = new PaymentService(paymentRepository, invoiceRepository, userRepository);
+        paymentService = new PaymentService(paymentRepository, invoiceRepository, userRepository, merchantProfileRepository);
     }
 
     private Invoice sampleInvoice() {

--- a/backend/src/test/java/com/ipos/ord/ORDOrderTest.java
+++ b/backend/src/test/java/com/ipos/ord/ORDOrderTest.java
@@ -42,6 +42,8 @@ import com.ipos.security.SecurityConfig;
 import com.ipos.config.IntegrationCaProperties;
 import com.ipos.service.InvoiceService;
 import com.ipos.service.OrderService;
+import com.ipos.service.StandingTransitionService;
+import static org.mockito.Mockito.mock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -99,7 +101,8 @@ public class ORDOrderTest {
                 orderRepository, productRepository, userRepository, profileRepository,
                 invoiceService,
                 invoiceRepository,
-                new IntegrationCaProperties());
+                new IntegrationCaProperties(),
+                mock(StandingTransitionService.class));
     }
 
     /* ── helpers ────────────────────────────────────────────────────────────── */

--- a/backend/src/test/java/com/ipos/service/MerchantAccountServiceTest.java
+++ b/backend/src/test/java/com/ipos/service/MerchantAccountServiceTest.java
@@ -112,7 +112,8 @@ public class MerchantAccountServiceTest {
                 orderRepository, productRepository, userRepository, profileRepository,
                 mock(InvoiceService.class),
                 invoiceRepository,
-                new IntegrationCaProperties());
+                new IntegrationCaProperties(),
+                mock(com.ipos.service.StandingTransitionService.class));
         lenient().when(invoiceRepository.sumPaymentsByMerchantId(anyLong())).thenReturn(BigDecimal.ZERO);
 
         userService = new UserService(userRepository, passwordEncoder);


### PR DESCRIPTION
- Auto IN_DEFAULT when credit limit is exceeded on order placement
- Auto SUSPENDED after 30 days in IN_DEFAULT
- Auto restore to NORMAL when outstanding balance is fully cleared
- Manager can only restore IN_DEFAULT to NORMAL if a payment (has to be partial payment since full payemnt automatically restores to normal) has been made
- StandingTransitionService uses REQUIRES_NEW to persist standing changes independently of the order transaction

